### PR TITLE
Move JNI lib init to DatabaseHandler instance.

### DIFF
--- a/StudIPAndroidApp/src/main/java/de/elanev/studip/android/app/StudIPApplication.java
+++ b/StudIPAndroidApp/src/main/java/de/elanev/studip/android/app/StudIPApplication.java
@@ -55,9 +55,6 @@ public class StudIPApplication extends Application {
       Fabric.with(this, new Crashlytics());
     }
 
-    // Load SQLCipher JNI Libs
-    SQLiteDatabase.loadLibs(this);
-
     // Enable StrictMode for debug builds
     if (BuildConfig.DEBUG) {
       StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectDiskReads()

--- a/StudIPAndroidApp/src/main/java/de/elanev/studip/android/app/backend/db/DatabaseHandler.java
+++ b/StudIPAndroidApp/src/main/java/de/elanev/studip/android/app/backend/db/DatabaseHandler.java
@@ -16,6 +16,7 @@ import java.io.File;
 
 import de.elanev.studip.android.app.BuildConfig;
 import de.elanev.studip.android.app.R;
+import de.elanev.studip.android.app.StudIPApplication;
 
 public class DatabaseHandler extends SQLiteOpenHelper {
   private static final Patch[] PATCHES = new Patch[]{
@@ -59,8 +60,11 @@ public class DatabaseHandler extends SQLiteOpenHelper {
    * @param context a context to get the application context for the database to live in
    * @return an DatabaseHandler instance
    */
-  public static DatabaseHandler getInstance(Context context) {
+  public static synchronized DatabaseHandler getInstance(Context context) {
     if (sInstance == null) {
+      // Load SQLCipher JNI Libs
+      SQLiteDatabase.loadLibs(StudIPApplication.getInstance());
+      
       sInstance = new DatabaseHandler(context.getApplicationContext());
     }
 


### PR DESCRIPTION
It's possible that the JNI will not be initialized once the App resumes
after suspension. Moving to the DatabaseHandler instance should ensure
that the libs are initialized every time the database is requested.
Loading shared libs multiple times shouldn't have an impact on
performance. This hopefully fixes #103 